### PR TITLE
Templates cache

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,4 +1,3 @@
-
 ###> symfony/framework-bundle ###
 APP_SECRET=4fae171f2327d00de8d1389d9be71994
 ###< symfony/framework-bundle ###

--- a/.env.dev
+++ b/.env.dev
@@ -1,3 +1,3 @@
 ###> symfony/framework-bundle ###
-APP_SECRET=4fae171f2327d00de8d1389d9be71994
+APP_SECRET=
 ###< symfony/framework-bundle ###

--- a/.env.example
+++ b/.env.example
@@ -5,14 +5,6 @@
 ###< symfony/framework-bundle ###
 
 ###> doctrine/doctrine-bundle ###
-#DATABASE_MAIN_HOST=
-#DATABASE_MAIN_PORT=7003
-#DATABASE_MAIN_USER=
-#DATABASE_MAIN_PASSWORD=
-#DATABASE_MAIN_DBNAME=php-sf-playground-db-postgresql
-#DATABASE_MAIN_VERSION=16.1.0
-# Optional: override test DB name (default: DATABASE_MAIN_DBNAME + _test)
-#DATABASE_MAIN_DBNAME_TEST=
 ###< doctrine/doctrine-bundle ###
 
 #REDIS_CACHE_URL=redis://localhost:6379/10

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,3 @@
-DEVELOPMENT_STAGE=1.0.0
-
 ###> symfony/framework-bundle ###
 # dev, test, prod
 #APP_ENV=dev
@@ -7,6 +5,14 @@ DEVELOPMENT_STAGE=1.0.0
 ###< symfony/framework-bundle ###
 
 ###> doctrine/doctrine-bundle ###
+#DATABASE_MAIN_HOST=
+#DATABASE_MAIN_PORT=7003
+#DATABASE_MAIN_USER=
+#DATABASE_MAIN_PASSWORD=
+#DATABASE_MAIN_DBNAME=php-sf-playground-db-postgresql
+#DATABASE_MAIN_VERSION=16.1.0
+# Optional: override test DB name (default: DATABASE_MAIN_DBNAME + _test)
+#DATABASE_MAIN_DBNAME_TEST=
 ###< doctrine/doctrine-bundle ###
 
 #REDIS_CACHE_URL=redis://localhost:6379/10

--- a/App/Http/Controller/ExampleController.php
+++ b/App/Http/Controller/ExampleController.php
@@ -17,6 +17,7 @@ namespace App\Http\Controller;
 
 use App\Http\Middleware\blank;
 use App\View\welcome_page;
+use Composer\InstalledVersions;
 use PHP_SF\Framework\Http\Middleware\admin_example;
 use PHP_SF\Framework\Http\Middleware\api_example;
 use PHP_SF\Framework\Http\Middleware\auth;
@@ -36,16 +37,8 @@ final class ExampleController extends AbstractController
     #[Route( url: '/', httpMethod: 'GET', middleware: [ blank::class ] )]
     public function welcome_page(): Response
     {
-        $composerLock = j_decode( file_get_contents( project_dir() . '/composer.lock' ), true );
-        foreach ( $composerLock['packages'] as $package ) {
-            if ( $package['name'] !== 'nations-original/php-simple-framework' )
-                continue;
-
-            break;
-        }
-
         return $this->render( welcome_page::class, [
-            'framework_version' => $package['version'],
+            'framework_version' => InstalledVersions::getPrettyVersion( 'nations-original/php-simple-framework' ),
         ] );
     }
 

--- a/App/Http/Controller/ExampleController.php
+++ b/App/Http/Controller/ExampleController.php
@@ -22,7 +22,6 @@ use PHP_SF\Framework\Http\Middleware\api_example;
 use PHP_SF\Framework\Http\Middleware\auth;
 use PHP_SF\System\Attributes\Route;
 use PHP_SF\System\Classes\Abstracts\AbstractController;
-use PHP_SF\System\Classes\MiddlewareChecks\MiddlewareAll as all;
 use PHP_SF\System\Classes\MiddlewareChecks\MiddlewareAny as any;
 use PHP_SF\System\Classes\MiddlewareChecks\MiddlewareCustom as custom;
 use PHP_SF\System\Core\RedirectResponse;
@@ -37,10 +36,20 @@ final class ExampleController extends AbstractController
     #[Route( url: '/', httpMethod: 'GET', middleware: [ blank::class ] )]
     public function welcome_page(): Response
     {
-        return $this->render( welcome_page::class );
+        $composerLock = j_decode( file_get_contents( project_dir() . '/composer.lock' ), true );
+        foreach ( $composerLock['packages'] as $package ) {
+            if ( $package['name'] !== 'nations-original/php-simple-framework' )
+                continue;
+
+            break;
+        }
+
+        return $this->render( welcome_page::class, [
+            'framework_version' => $package['version'],
+        ] );
     }
 
-    #[Route( url: 'example/page/{$response_type}', httpMethod: 'GET', middleware: [ custom::class => [ any::class => [ auth::class, api_example::class, admin_example::class ] ] ] )]
+    #[Route( url: 'example/page/{response_type}', httpMethod: 'GET', middleware: [ custom::class => [ any::class => [ auth::class, api_example::class, admin_example::class ] ] ] )]
     public function example_route( string $response_type ): Response|RedirectResponse|JsonResponse
     {
         // Return Response

--- a/templates/welcome_page.php
+++ b/templates/welcome_page.php
@@ -4,17 +4,13 @@ namespace App\View;
 
 use PHP_SF\System\Classes\Abstracts\AbstractView;
 
+/**
+ * @property string $framework_version
+ */
 // @formatter:off
 final class welcome_page extends AbstractView { public function show(): void { ?>
   <!--@formatter:on-->
 
-    <!DOCTYPE html>
-    <html dir="ltr" lang="en">
-    <head>
-        <meta charset="UTF-8" />
-        <meta name="robots" content="noindex,nofollow,noarchive,nosnippet,noodp,notranslate,noimageindex" />
-        <title>Welcome to Symfony!</title>
-        <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 128 128%22><text y=%221.2em%22 font-size=%2296%22>👋</text></svg>">
         <style>
             <?php $hue = random_int(0, 360); ?>
             <?php $darkColor = static function (float $alpha = 1) use ($hue) { return "hsla($hue, 20%, 45%, $alpha)"; }; ?>
@@ -77,8 +73,6 @@ final class welcome_page extends AbstractView { public function show(): void { ?
               width: 100%;
             }
         </style>
-    </head>
-    <body>
     <div class="wrapper">
         <div class="container">
             <div class="welcome">
@@ -87,7 +81,7 @@ final class welcome_page extends AbstractView { public function show(): void { ?
                 </div>
                 <h1>
                   <small>Welcome to</small>
-                  PHP_SF <span class="version"><?= env( 'DEVELOPMENT_STAGE' ) ?></span>
+                  PHP_SF <span class="version"><?= $this->framework_version ?></span>
                   <small style="font-size: 50%;">(Based on Symfony 7)</small>
                 </h1>
             </div>
@@ -110,29 +104,28 @@ final class welcome_page extends AbstractView { public function show(): void { ?
                 <div class="resource">
                     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 11.55C9.64 9.35 6.48 8 3 8v11c3.48 0 6.64 1.35 9 3.55 2.36-2.19 5.52-3.55 9-3.55V8c-3.48 0-6.64 1.35-9 3.55zM12 8c1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3 1.34 3 3 3z"/></svg>
                     <h2>Documentation</h2>
-                    <a href="https://phpsf.wiki">
+                    <a href="https://wiki.nations-original.com/framework">
                         Guides, components, references
                     </a>
                 </div>
                 <div class="resource">
                     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="none" d="M0 0h24v24H0V0z"/><path d="M9.4 16.6L4.8 12l4.6-4.6L8 6l-6 6 6 6 1.4-1.4zm5.2 0l4.6-4.6-4.6-4.6L16 6l6 6-6 6-1.4-1.4z"/></svg>
                     <h2>Tutorials</h2>
-                  <a href="https://phpsf.wiki/first_page">
+                  <a href="https://wiki.nations-original.com/en/framework/getting-started/first_page">
                         Create your first page
                     </a>
                 </div>
                 <div class="resource">
                     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M0 0h24v24H0z" fill="none"/><path d="M16 11c1.66 0 2.99-1.34 2.99-3S17.66 5 16 5c-1.66 0-3 1.34-3 3s1.34 3 3 3zm-8 0c1.66 0 2.99-1.34 2.99-3S9.66 5 8 5C6.34 5 5 6.34 5 8s1.34 3 3 3zm0 2c-2.33 0-7 1.17-7 3.5V19h14v-2.5c0-2.33-4.67-3.5-7-3.5zm8 0c-.29 0-.62.02-.97.05 1.16.84 1.97 1.97 1.97 3.45V19h6v-2.5c0-2.33-4.67-3.5-7-3.5z"/></svg>
                     <h2>Community</h2>
-                  <a href="https://phpsf.wiki/community">
+                  <a href="https://github.com/Ondottr/PHP_SF_Template">
                         Connect, get help, or contribute
                     </a>
                 </div>
             </div>
         </div>
     </div>
-    </body>
-    </html>
+
 
 
     <!--@formatter:off-->


### PR DESCRIPTION
This pull request updates the application's welcome page to display the actual framework version from `composer.lock`, modernizes documentation and tutorial links, and removes unused and outdated environment variables. It also cleans up some HTML structure and improves code clarity.

**Welcome page improvements:**
- The welcome page now dynamically displays the framework version by reading it from `composer.lock`, replacing the previous usage of the `DEVELOPMENT_STAGE` environment variable. (`App/Http/Controller/ExampleController.php`, `templates/welcome_page.php`) ([App/Http/Controller/ExampleController.phpL40-R52](diffhunk://#diff-6c6326e6e442faf3855c5b608a96a788dcf470c755632989328796e37db10adfL40-R52), Fe213d01L81)
- Documentation, tutorial, and community links on the welcome page have been updated to point to the new, correct URLs. (`templates/welcome_page.php`) (Fe213d01L104)

**Environment and configuration cleanup:**
- Removed the unused `DEVELOPMENT_STAGE` variable from `.env.example` and cleaned up `.env.dev`. [[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL1-L2) [[2]](diffhunk://#diff-7a7fc1ad605f5451f39444d73266644788cd3cfb0cf432d1f0022643dbe50da3L1)

**Code and markup cleanup:**
- Removed an unused import in `ExampleController.php` and corrected a typo in the route path. [[1]](diffhunk://#diff-6c6326e6e442faf3855c5b608a96a788dcf470c755632989328796e37db10adfL25) [[2]](diffhunk://#diff-6c6326e6e442faf3855c5b608a96a788dcf470c755632989328796e37db10adfL40-R52)
- Cleaned up the HTML structure in the welcome page template for better maintainability. (`templates/welcome_page.php`) (Fe213d01L73, [templates/welcome_page.phpL113-R128](diffhunk://#diff-7112f48538c671a55c70d4b3caa8742b6c426d0e79cca1d1ac488efdf16db218L113-R128))