### PR TITLE
Standardized API response envelope

### DIFF
--- a/tests/Unit/ApiResponseCest.php
+++ b/tests/Unit/ApiResponseCest.php
@@ -1,8 +1,9 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Tests\Unit;
 
 use PHP_SF\System\Classes\Helpers\CursorPaginationResult;
+use PHP_SF\System\Classes\Helpers\PaginationCursor;
 use PHP_SF\System\Core\ApiResponse;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Tests\Support\Uni2Tester;
@@ -40,10 +41,16 @@ class ApiResponseCest
 
     public function testPaginatedResponseContainsMeta(Uni2Tester $I): void
     {
+        $entity = new class {
+            public function getCreatedAt(): int { return 1700000000; }
+            public function getId(): int { return 21; }
+        };
+
+        $next   = PaginationCursor::after($entity, 'createdAt');
         $result = new CursorPaginationResult(
             items:      [['id' => 1], ['id' => 2]],
             cursor:     null,
-            nextCursor: 'eyJpZCI6Mn0=',
+            nextCursor: $next,
             prevCursor: null,
             perPage:    20,
             hasMore:    true,
@@ -53,7 +60,7 @@ class ApiResponseCest
         $body = json_decode($r->getContent(), associative: true);
 
         $I->assertNotNull($body['meta']['pagination']);
-        $I->assertSame('eyJpZCI6Mn0=', $body['meta']['pagination']['next_cursor']);
+        $I->assertSame($next->toString(), $body['meta']['pagination']['next_cursor']);
         $I->assertTrue($body['meta']['pagination']['has_more']);
         $I->assertSame(20, $body['meta']['pagination']['per_page']);
     }

--- a/tests/Unit/ApiResponseCest.php
+++ b/tests/Unit/ApiResponseCest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHP_SF\System\Classes\Helpers\CursorPaginationResult;
+use PHP_SF\System\Core\ApiResponse;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Tests\Support\Uni2Tester;
+
+class ApiResponseCest
+{
+
+    public function testExtendsJsonResponse(Uni2Tester $I): void
+    {
+        $I->assertInstanceOf(JsonResponse::class, ApiResponse::success());
+    }
+
+    public function testSuccessBodyStructure(Uni2Tester $I): void
+    {
+        $r    = ApiResponse::success(['key' => 'value']);
+        $body = json_decode($r->getContent(), associative: true);
+
+        $I->assertTrue($body['success']);
+        $I->assertSame(['key' => 'value'], $body['data']);
+        $I->assertNull($body['errors']);
+        $I->assertArrayHasKey('timestamp', $body['meta']);
+        $I->assertNull($body['meta']['pagination']);
+    }
+
+    public function testErrorBodyStructure(Uni2Tester $I): void
+    {
+        $r    = ApiResponse::error('Oops', 422);
+        $body = json_decode($r->getContent(), associative: true);
+
+        $I->assertFalse($body['success']);
+        $I->assertNull($body['data']);
+        $I->assertSame(['Oops'], $body['errors']);
+        $I->assertSame(422, $r->getStatusCode());
+    }
+
+    public function testPaginatedResponseContainsMeta(Uni2Tester $I): void
+    {
+        $result = new CursorPaginationResult(
+            items:      [['id' => 1], ['id' => 2]],
+            cursor:     null,
+            nextCursor: 'eyJpZCI6Mn0=',
+            prevCursor: null,
+            perPage:    20,
+            hasMore:    true,
+        );
+
+        $r    = ApiResponse::success(data: [['id' => 1], ['id' => 2]], pagination: $result);
+        $body = json_decode($r->getContent(), associative: true);
+
+        $I->assertNotNull($body['meta']['pagination']);
+        $I->assertSame('eyJpZCI6Mn0=', $body['meta']['pagination']['next_cursor']);
+        $I->assertTrue($body['meta']['pagination']['has_more']);
+        $I->assertSame(20, $body['meta']['pagination']['per_page']);
+    }
+
+    public function testCreatedIs201(Uni2Tester $I): void
+    {
+        $I->assertSame(201, ApiResponse::created()->getStatusCode());
+    }
+
+    public function testNotFoundIs404(Uni2Tester $I): void
+    {
+        $I->assertSame(404, ApiResponse::notFound('Not here.')->getStatusCode());
+    }
+
+}


### PR DESCRIPTION
## Description

Wires up the framework's new API response envelope and cursor pagination infrastructure, migrates framework-internal error responses, and adds wiki documentation.

**Framework changes consumed (from `nations-original/php-simple-framework`):**
- `ApiResponse` — `{ success, data, errors, meta }` envelope
- `PaginationCursor` — value object for cursor encoding/decoding
- `CursorPaginationHelper` / `CursorPaginationResult` — cursor-based QB pagination
- `JsonResponseHelperTrait` `api*` methods on every controller via `AbstractController`

**Changes in this repo:**
- `Middleware.php`, `auth.php`, `Router.php` — framework-internal `new JsonResponse([...])` error responses replaced with `ApiResponse::forbidden()` / `ApiResponse::unauthorized()` / `ApiResponse::notFound()`

No changes to `App/` controllers — existing code is unaffected. `ApiResponse extends JsonResponse` so all return types and `instanceof` checks remain valid.

## Type of change

- [ ] Bug fix
- [x] New feature / improvement
- [ ] Refactor (no behaviour change)
- [ ] Documentation / tooling
- [x] Dependency update

## Testing

- [x] Existing tests pass (`vendor/bin/codecept run`)
- [x] New tests added (or not applicable — explain below)

New test file:
- `tests/Unit/ApiResponseCest.php` — 6 Codeception unit tests covering envelope shape, paginated response metadata, and status codes

## Checklist

- [x] All test cases passed
- [ ] All commits signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
