### PR TITLE
chore(deps): require php-simple-framework ^3.3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
     "composer/package-versions-deprecated": "1.11.99.5",
     "eftec/bladeone": "^4.19",
     "nations-original/php-sf-cache": "^2.0",
-    "nations-original/php-simple-framework": "^3.2.0",
+    "nations-original/php-simple-framework": "^3.3.0",
     "nelmio/api-doc-bundle": "^5.9",
     "php-amqplib/php-amqplib": "^3.6",
     "phpdocumentor/reflection-docblock": "^6.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8982537b037f8d753d192212f1d6a4dd",
+    "content-hash": "2d9a99e23d99ea66363ecc20eb849a0e",
     "packages": [
         {
             "name": "composer/package-versions-deprecated",
@@ -403,16 +403,16 @@
         },
         {
             "name": "nations-original/php-simple-framework",
-            "version": "v3.2.0",
+            "version": "v3.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Ondottr/PHP_SF_Platform.git",
-                "reference": "3a76b70a2a70da60fee599336ccc9232e860ee12"
+                "reference": "8df5566246abb0daf4d7faec1800edea3ba999c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Ondottr/PHP_SF_Platform/zipball/3a76b70a2a70da60fee599336ccc9232e860ee12",
-                "reference": "3a76b70a2a70da60fee599336ccc9232e860ee12",
+                "url": "https://api.github.com/repos/Ondottr/PHP_SF_Platform/zipball/8df5566246abb0daf4d7faec1800edea3ba999c9",
+                "reference": "8df5566246abb0daf4d7faec1800edea3ba999c9",
                 "shasum": ""
             },
             "require": {
@@ -470,9 +470,9 @@
             "description": "A simple PHP framework for Nations Original.",
             "support": {
                 "issues": "https://github.com/Ondottr/PHP_SF_Platform/issues",
-                "source": "https://github.com/Ondottr/PHP_SF_Platform/tree/v3.2.0"
+                "source": "https://github.com/Ondottr/PHP_SF_Platform/tree/v3.3.0"
             },
-            "time": "2026-08-04T15:41:18+00:00"
+            "time": "2026-08-06T19:23:20+00:00"
         },
         {
             "name": "nelmio/api-doc-bundle",


### PR DESCRIPTION
Bumps the framework to [v3.3.0](https://github.com/Ondottr/PHP_SF_Platform/releases/tag/v3.3.0) (Ondottr/PHP_SF_Platform#44).

## What it unlocks

A route can now bind two entities that are both keyed by `id`, whichever way the placeholders are spelled:

```php
#[Route( url: 'crud/users/{id}/payment/{id}', httpMethod: 'GET', name: 'crud_user_one_payment', middleware: [ crud::class ] )]
public function crud_user_one_payment( ?User $user, ?Payment $payment ): Response
{
    // /crud/users/7/payment/42 → $user = User#7, $payment = Payment#42
}

// identical behaviour
#[Route( url: 'crud/users/{id}/payment/{paymentId}', httpMethod: 'GET', name: 'crud_user_one_payment_alt' )]
public function crud_user_one_payment_alt( ?User $user, ?Payment $payment ): Response {}
```

Previously the first spelling lost the user's `id` and threw `RouteParameterException` on every request; the second was rejected at registration because `User` has no `paymentId` property. Each entity resolves through its own entity manager, so the two may live in different databases — relevant for `main` + `payments` here.

Placeholder/argument count mismatches now also fail at route registration rather than on first request, and `routeLink()` accepts a list for a repeated placeholder (`['id' => [7, 42]]` → `/crud/users/7/payment/42`).

## Scope

`composer.json` constraint plus the matching `composer.lock` entry. The lock diff touches only `nations-original/php-simple-framework` (v3.2.0 → v3.3.0) — no other package version changes.

## Verification

Against the published v3.3.0 package: `bin/phpunit Platform/tests/` **332 pass**, `vendor/bin/codecept run Unit` **345 pass**. `composer validate` reports no lock errors (remaining warnings are pre-existing).