### PR TITLE
Use php-simple-framework v4.1.0; disable translation auto-write in tests

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -648,16 +648,16 @@
         },
         {
             "name": "nations-original/php-simple-framework",
-            "version": "v4.0.0",
+            "version": "v4.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Ondottr/PHP_SF_Platform.git",
-                "reference": "f50c0e0d1acaf291a141211bea9d85afdfdb4d9a"
+                "reference": "7dbc4444a76f6464bad671570b9e0f83093f1350"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Ondottr/PHP_SF_Platform/zipball/f50c0e0d1acaf291a141211bea9d85afdfdb4d9a",
-                "reference": "f50c0e0d1acaf291a141211bea9d85afdfdb4d9a",
+                "url": "https://api.github.com/repos/Ondottr/PHP_SF_Platform/zipball/7dbc4444a76f6464bad671570b9e0f83093f1350",
+                "reference": "7dbc4444a76f6464bad671570b9e0f83093f1350",
                 "shasum": ""
             },
             "require": {
@@ -715,9 +715,9 @@
             "description": "A simple PHP framework for Nations Original.",
             "support": {
                 "issues": "https://github.com/Ondottr/PHP_SF_Platform/issues",
-                "source": "https://github.com/Ondottr/PHP_SF_Platform/tree/v4.0.0"
+                "source": "https://github.com/Ondottr/PHP_SF_Platform/tree/v4.1.0"
             },
-            "time": "2026-08-09T09:45:51+00:00"
+            "time": "2026-08-18T09:15:26+00:00"
         },
         {
             "name": "nelmio/api-doc-bundle",
@@ -1433,16 +1433,16 @@
         },
         {
             "name": "predis/predis",
-            "version": "v3.5.1",
+            "version": "v3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/predis/predis.git",
-                "reference": "5c996db191ee2d9bafe651f454b1fca16754271b"
+                "reference": "2ff20c08bb63697245ffee3f198d1673086c302d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/predis/predis/zipball/5c996db191ee2d9bafe651f454b1fca16754271b",
-                "reference": "5c996db191ee2d9bafe651f454b1fca16754271b",
+                "url": "https://api.github.com/repos/predis/predis/zipball/2ff20c08bb63697245ffee3f198d1673086c302d",
+                "reference": "2ff20c08bb63697245ffee3f198d1673086c302d",
                 "shasum": ""
             },
             "require": {
@@ -1484,7 +1484,7 @@
             ],
             "support": {
                 "issues": "https://github.com/predis/predis/issues",
-                "source": "https://github.com/predis/predis/tree/v3.5.1"
+                "source": "https://github.com/predis/predis/tree/v3.6.0"
             },
             "funding": [
                 {
@@ -1492,7 +1492,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-11T16:56:53+00:00"
+            "time": "2026-08-14T23:07:56+00:00"
         },
         {
             "name": "psr/cache",

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -13,6 +13,11 @@ defined('start_time') || define('start_time', microtime(true));
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
+// Tests pass arbitrary/DB-derived keys to _t() (e.g. game_setting.*). DEV_MODE
+// auto-discovery would otherwise persist a {key}_not_translated placeholder into the
+// committed translation files on every run — disable it so suites never mutate YAML.
+\PHP_SF\System\Core\TranslatorV2::setAutoWriteMissingKeys(false);
+
 // PHPUnit sets APP_ENV=test via phpunit.xml.dist <server> before this runs.
 // Codeception does not, so we default it here so bootEnv('.env') picks up .env.test.
 $_SERVER['APP_ENV'] ??= 'test';


### PR DESCRIPTION
## Description

Uses the just-released **php-simple-framework v4.1.0** and disables the framework's DEV_MODE missing-key auto-discovery in the test bootstrap.

**Why:** functional suites call `_t()` with arbitrary/DB-derived keys (e.g. `game_setting.*`), and the previous behaviour persisted a `{key}_not_translated` placeholder into the committed `translations/en.yaml` on every run. v4.1.0 adds `TranslatorV2::setAutoWriteMissingKeys()`, letting the app opt out. This PR wires that opt-out and bumps the dependency (lock now resolves the new `v4.1.0` tag).

## Type of change

- [ ] Bug fix
- [x] New feature / improvement
- [ ] Refactor (no behaviour change)
- [ ] Documentation / tooling
- [x] Dependency update

## Testing

- [x] Existing tests pass (`vendor/bin/codecept run`)
- [ ] New tests added (or not applicable — explain below)

The framework change this depends on already lands with its own test (Ondottr/PHP_SF_Platform#47, released as v4.1.0). The bootstrap call is guarded by the framework method; `composer.lock` pins framework + transitive php-sf-cache.

## Checklist

- [x] `declare(strict_types=1)` where applicable
- [x] No `@author` tags / unnecessary docblocks / license headers added
- [x] Commits signed off (`git commit -s`) per DCO